### PR TITLE
Increase the resulting string length of GROUP_CONCAT from 1024 to 4096

### DIFF
--- a/core/database.rb
+++ b/core/database.rb
@@ -5,6 +5,7 @@ require 'mysql2'
 module Database
   DATABASE_CONFIG_PATH = File.expand_path("../database.yml", __dir__)
   DATABASE_CONFIG = YAML.load_file(DATABASE_CONFIG_PATH)
+  DATABASE_CONFIG["init_command"] = "SET SESSION group_concat_max_len=4096;"
   REQUIRED_TABLES = %w(
     championships
     Competitions


### PR DESCRIPTION
In the statistic `most_attended_competitions_in_single_month` the SQL function `GROUP_CONCAT` is used to create a list of attended competitions for the month, with URL links and human-readable names.

Unfortunately, the resulting string has a default length of 1024, which is no longer sufficient for the top two competitors, and their competition lists are truncated.
![GroupConcatBugBefore](https://github.com/jonatanklosko/wca_statistics/assets/4593694/04e0c63e-ec01-4369-af55-d19f99a7721d)

This PR addresses the problem by adding an `init_command` to the SQL client initialisation code that sets the session variable `group_concat_max_len` to a larger value of 4096. This should be sufficient until someone manages to attend more than 47 competitions in a single month.
![GroupConcatBugAfter](https://github.com/jonatanklosko/wca_statistics/assets/4593694/c7d9f24a-e2bc-4157-b9e9-567c3991db08)
