### PR TITLE
Add the FMC country code XW to the list of excluded countries in most_visited_countries.rb

### DIFF
--- a/statistics/competition_days_count_by_region.rb
+++ b/statistics/competition_days_count_by_region.rb
@@ -15,7 +15,9 @@ class CompetitionDaysCountByRegion < GroupedStatistic
       FROM Competitions
       JOIN Countries country ON country.id = countryId
       JOIN Continents continent ON continent.id = continentId
-      WHERE countryId NOT IN ('XA', 'XE', 'XM', 'XS') AND continentId != "_Multiple Continents"
+      WHERE countryId -- Ignore Multiple Countries used for continental FMC competitions.
+        NOT IN ('XA', 'XE', 'XF', 'XM', 'XN', 'XO', 'XS', 'XW')
+        AND continentId != "_Multiple Continents"
     SQL
   end
 

--- a/statistics/most_competitions_abroad.rb
+++ b/statistics/most_competitions_abroad.rb
@@ -19,7 +19,8 @@ class MostCompetitionsAbroad < Statistic
         JOIN Competitions competition ON competition.id = competitionId
         WHERE 1
           AND result.countryId != competition.countryId
-          AND competition.countryId NOT IN ('XA', 'XE', 'XM', 'XS') -- Ignore Multiple Countries used for continental FMC competitions.
+          AND competition.countryId -- Ignore Multiple Countries used for continental FMC competitions.
+            NOT IN ('XA', 'XE', 'XF', 'XM', 'XN', 'XO', 'XS', 'XW')
         GROUP BY personId
         ORDER BY competitions_abroad DESC
         LIMIT 100

--- a/statistics/most_visited_countries.rb
+++ b/statistics/most_visited_countries.rb
@@ -18,7 +18,7 @@ class MostVisitedCountries < Statistic
         FROM Results result
         JOIN Competitions competition ON competition.id = competitionId
         WHERE competition.countryId -- Ignore Multiple Countries used for continental FMC competitions.
-          NOT IN ('XA', 'XE', 'XF', 'XM', 'XN', 'XO', 'XS', 'XW') 
+          NOT IN ('XA', 'XE', 'XF', 'XM', 'XN', 'XO', 'XS', 'XW')
         GROUP BY personId
         ORDER BY visited_countries DESC
         LIMIT 100

--- a/statistics/most_visited_countries.rb
+++ b/statistics/most_visited_countries.rb
@@ -17,7 +17,7 @@ class MostVisitedCountries < Statistic
           COUNT(DISTINCT competition.countryId) visited_countries
         FROM Results result
         JOIN Competitions competition ON competition.id = competitionId
-        WHERE competition.countryId NOT IN ('XA', 'XE', 'XM', 'XS') -- Ignore Multiple Countries used for continental FMC competitions.
+        WHERE competition.countryId NOT IN ('XA', 'XE', 'XM', 'XS', 'XW') -- Ignore Multiple Countries used for continental FMC competitions.
         GROUP BY personId
         ORDER BY visited_countries DESC
         LIMIT 100

--- a/statistics/most_visited_countries.rb
+++ b/statistics/most_visited_countries.rb
@@ -17,7 +17,8 @@ class MostVisitedCountries < Statistic
           COUNT(DISTINCT competition.countryId) visited_countries
         FROM Results result
         JOIN Competitions competition ON competition.id = competitionId
-        WHERE competition.countryId NOT IN ('XA', 'XE', 'XM', 'XS', 'XW') -- Ignore Multiple Countries used for continental FMC competitions.
+        WHERE competition.countryId -- Ignore Multiple Countries used for continental FMC competitions.
+          NOT IN ('XA', 'XE', 'XF', 'XM', 'XN', 'XO', 'XS', 'XW') 
         GROUP BY personId
         ORDER BY visited_countries DESC
         LIMIT 100


### PR DESCRIPTION
In the statistic `most_visited_countries` there is a list of FMC "countries" that are to be excluded when counting how many countries a competitor has visited. These are currently `XA`, `XE`, `XM`, and `XS`. 

However, there is a fifth "country", `XW`, that is currently not excluded, but is counted towards the number of countries a competitor has visited. Two of my friends, [AJ Nicholls](https://www.worldcubeassociation.org/persons/2015NICH04) and [Philippe Schwartz](https://www.worldcubeassociation.org/persons/2018SCHW02) have noticed that they have one too many countries against their names, and asked me to take a look. 

When I debugged the script I saw that the both had `XW` among their countries, and when I added `XW` to the exclude list, they both had the correct number of countries by their names.