### PR TITLE
Added new stat for most comps in a single week

### DIFF
--- a/statistics/most_attended_competitions_in_single_week.rb
+++ b/statistics/most_attended_competitions_in_single_week.rb
@@ -18,8 +18,8 @@ class MostAttendedCompetitionsInSingleWeek < Statistic
         SELECT
           COUNT(*) attended_within_week,
           personId,
-          DATE_ADD(competition.start_date, INTERVAL(-1-WEEKDAY(competition.start_date)) DAY) week_start_date, 
-          DATE_ADD(competition.start_date, INTERVAL(5-WEEKDAY(competition.start_date)) DAY) week_end_date,
+          DATE_ADD(competition.start_date, INTERVAL(-WEEKDAY(competition.start_date)) DAY) week_start_date, 
+          DATE_ADD(competition.start_date, INTERVAL(6-WEEKDAY(competition.start_date)) DAY) week_end_date,
           GROUP_CONCAT(
             CONCAT('[', competition.cellName, '](https://www.worldcubeassociation.org/competitions/', competition.id, ')')
             SEPARATOR ', '

--- a/statistics/most_attended_competitions_in_single_week.rb
+++ b/statistics/most_attended_competitions_in_single_week.rb
@@ -1,0 +1,39 @@
+require_relative "../core/statistic"
+
+class MostAttendedCompetitionsInSingleWeek < Statistic
+  def initialize
+    @title = "Most attended competitions in a single week"
+    @table_header = { "Competitions" => :right, "Person" => :left, "Week" => :left, "Year" => :left, "List" => :left }
+  end
+
+  def query
+    <<-SQL
+      SELECT
+        attended_within_week,
+        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.id, ')') person_link,
+        week_number,
+        competitions_year,
+        competition_links
+      FROM (
+        SELECT
+          COUNT(*) attended_within_week,
+          personId,
+          WEEK(competition.start_date, 0) week_number,
+          competition.year competitions_year,
+          GROUP_CONCAT(
+            CONCAT('[', competition.cellName, '](https://www.worldcubeassociation.org/competitions/', competition.id, ')')
+            SEPARATOR ', '
+          ) competition_links
+        FROM (
+          SELECT DISTINCT competitionId, personId
+          FROM Results
+        ) AS results
+        JOIN Competitions competition ON competition.id = competitionId
+        GROUP BY personId, competition.year, week_number
+        HAVING attended_within_week >= 3
+      ) AS comps_within_single_month_by_person
+      JOIN Persons person ON person.id = personId AND subId = 1
+      ORDER BY attended_within_week DESC, person.name
+    SQL
+  end
+end


### PR DESCRIPTION
Added a new statistic for the most attended competitions in a single week. A week is considered to start on a Sunday for the purposes of this stat. I'm definitely open to discussing that choice if anyone thinks it was a bad one.

Here's how it looks when rendered in IntelliJ:
![MostCompsInWeek](https://github.com/jonatanklosko/wca_statistics/assets/4593694/723b5778-6666-4540-87cf-c404bd1cbd3e)
