### PR TITLE
Order competition lists by the start dates of the competitions

### DIFF
--- a/statistics/most_attended_competitions_in_single_month.rb
+++ b/statistics/most_attended_competitions_in_single_month.rb
@@ -22,6 +22,7 @@ class MostAttendedCompetitionsInSingleMonth < Statistic
           competition.year competitions_year,
           GROUP_CONCAT(
             CONCAT('[', competition.cellName, '](https://www.worldcubeassociation.org/competitions/', competition.id, ')')
+            ORDER BY competition.start_date ASC
             SEPARATOR ', '
           ) competition_links
         FROM (

--- a/statistics/most_attended_competitions_in_single_week.rb
+++ b/statistics/most_attended_competitions_in_single_week.rb
@@ -22,6 +22,7 @@ class MostAttendedCompetitionsInSingleWeek < Statistic
           DATE_ADD(competition.start_date, INTERVAL(6-WEEKDAY(competition.start_date)) DAY) week_end_date,
           GROUP_CONCAT(
             CONCAT('[', competition.cellName, '](https://www.worldcubeassociation.org/competitions/', competition.id, ')')
+            ORDER BY competition.start_date ASC
             SEPARATOR ', '
           ) competition_links
         FROM (


### PR DESCRIPTION
In the statistics `most_attended_competitions_in_single_week` and `most_attended_competitions_in_single_month`, there is a list of the competitions attended, but the list is not in order.

This PR orders the competitions in the lists by start date, resulting in the following (for the month example): 
![OrderedComps](https://github.com/jonatanklosko/wca_statistics/assets/4593694/ef823dac-c27e-4024-a085-f4e1393bab1e)
