### PR TITLE
Sort average_of_x statistics numerically instead of alphabetically

### DIFF
--- a/bin/compute_index.rb
+++ b/bin/compute_index.rb
@@ -1,22 +1,15 @@
 #!/usr/bin/env ruby
 
 require_relative "../statistics/index"
-
-# Sort certain statistics numerically rather than alphabetically.
-def order(a, b)
-  # List of affected statistics (with numbers removed)
-  ["average_of_"].each do |id|
-    if(a[0].gsub(/\d/, '') == id and b[0].gsub(/\d/, '') == id)
-      return a[0].gsub(/\D/, '').to_i <=> b[0].gsub(/\D/, '').to_i
-    end
-  end
-  a <=> b
-end
-
 # Generate statistics index.
 puts "Computing statistics index."
 build_path = File.expand_path("../build", __dir__)
-list = STATISTICS.sort{ |a, b| order(a, b) }.map { |statistics_id, statistic_object| "- [#{statistic_object.title}](#{statistics_id})\n" }.join
+
+list = STATISTICS
+  .sort_by { |statistics_id, statistic_object| statistic_object.title.gsub(/\d+/) { |number| number.rjust(10, "0") } }
+  .map { |statistics_id, statistic_object| "- [#{statistic_object.title}](#{statistics_id})\n" }
+  .join
+
 destination_path = File.join(build_path, "README.md")
 File.write(destination_path, list)
 puts "File generated at #{destination_path}"

--- a/bin/compute_index.rb
+++ b/bin/compute_index.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative "../statistics/index"
+
 # Generate statistics index.
 puts "Computing statistics index."
 build_path = File.expand_path("../build", __dir__)

--- a/bin/compute_index.rb
+++ b/bin/compute_index.rb
@@ -2,10 +2,21 @@
 
 require_relative "../statistics/index"
 
+# Sort certain statistics numerically rather than alphabetically.
+def order(a, b)
+  # List of affected statistics (with numbers removed)
+  ["average_of_"].each do |id|
+    if(a[0].gsub(/\d/, '') == id and b[0].gsub(/\d/, '') == id)
+      return a[0].gsub(/\D/, '').to_i <=> b[0].gsub(/\D/, '').to_i
+    end
+  end
+  a <=> b
+end
+
 # Generate statistics index.
 puts "Computing statistics index."
 build_path = File.expand_path("../build", __dir__)
-list = STATISTICS.sort.map { |statistics_id, statistic_object| "- [#{statistic_object.title}](#{statistics_id})\n" }.join
+list = STATISTICS.sort{ |a, b| order(a, b) }.map { |statistics_id, statistic_object| "- [#{statistic_object.title}](#{statistics_id})\n" }.join
 destination_path = File.join(build_path, "README.md")
 File.write(destination_path, list)
 puts "File generated at #{destination_path}"


### PR DESCRIPTION
Not a major problem, but I noticed this, which I find mildly confusing:
![image](https://github.com/jonatanklosko/wca_statistics/assets/46458276/15ccddcc-c24e-4f02-aa23-4dc3a2850de6)

I found a way to fix it, although since I don't know that much about Ruby, there might be a better solution.

You can see that it's working (and doesn't mess up the rest of the ordering) [here](https://justintimecuber.github.io/wca_statistics/).
![image](https://github.com/jonatanklosko/wca_statistics/assets/46458276/d0d4e21f-0430-408a-a64d-438c255376f5)