### PR TITLE
Round instead of truncating for average_of_x stats to match WCA

### DIFF
--- a/statistics/abstract/average_of_x.rb
+++ b/statistics/abstract/average_of_x.rb
@@ -77,6 +77,6 @@ class AverageOfX < GroupedStatistic
     values = untrimmed_solves
     mean_value = values.reduce(:+) / values.count.to_f
     mean_value *= 100 if event_id == "333fm" # Unify values for FMC to fit others
-    SolveTime.new(event_id, :average, mean_value.to_i)
+    SolveTime.new(event_id, :average, mean_value.round)
   end
 end


### PR DESCRIPTION
The average_of_x statistics use the `to_i` method to round the average, which results in truncation, for example:
![image](https://github.com/jonatanklosko/wca_statistics/assets/46458276/ced8baa7-1cc7-414a-b6cf-37c2c9e3e0a9)
Here the counting times are 4.81, 4.50, and 5.20, which average to 4.836667.

For comparison, the WCA uses rounding for calculation of official averages, for example, see the WR average:
![image](https://github.com/jonatanklosko/wca_statistics/assets/46458276/a05d7e27-ad0b-4995-9b58-413959c43554)
4.72, 4.72, and 3.99 average to 4.476667, but the WCA rounds this to 4.48.

I fixed this by replacing `to_i` with `round` in the `average` function.

(P.S. thanks to Keon Wilson for noticing this issue)