### PR TITLE
Exclude Multi-Country Competitions from Longest Competitions Path

### DIFF
--- a/statistics/longest_competitions_path.rb
+++ b/statistics/longest_competitions_path.rb
@@ -19,6 +19,7 @@ class LongestCompetitionsPath < Statistic
       ) AS people_with_competitions
       JOIN Persons person ON person.wca_id = personId AND subId = 1
       JOIN Competitions competition ON competition.id = competitionId
+      WHERE competition.countryId NOT IN ("XA","XE","XF","XM","XN","XO","XS","XW")
       ORDER BY competition.start_date, competition.end_date
     SQL
   end

--- a/statistics/longest_competitions_path.rb
+++ b/statistics/longest_competitions_path.rb
@@ -19,7 +19,8 @@ class LongestCompetitionsPath < Statistic
       ) AS people_with_competitions
       JOIN Persons person ON person.wca_id = personId AND subId = 1
       JOIN Competitions competition ON competition.id = competitionId
-      WHERE competition.countryId NOT IN ("XA","XE","XF","XM","XN","XO","XS","XW")
+      WHERE competition.countryId -- Ignore Multiple Countries used for continental FMC competitions.
+        NOT IN ("XA","XE","XF","XM","XN","XO","XS","XW")
       ORDER BY competition.start_date, competition.end_date
     SQL
   end

--- a/statistics/longest_competitions_path.rb
+++ b/statistics/longest_competitions_path.rb
@@ -20,7 +20,7 @@ class LongestCompetitionsPath < Statistic
       JOIN Persons person ON person.wca_id = personId AND subId = 1
       JOIN Competitions competition ON competition.id = competitionId
       WHERE competition.countryId -- Ignore Multiple Countries used for continental FMC competitions.
-        NOT IN ("XA","XE","XF","XM","XN","XO","XS","XW")
+        NOT IN ('XA', 'XE', 'XF', 'XM', 'XN', 'XO', 'XS', 'XW')
       ORDER BY competition.start_date, competition.end_date
     SQL
   end


### PR DESCRIPTION
Proposed change to the query to exclude competitions which take place in multiple countries from the longest competitions path statistic. Note that I have not run this locally so I may have missed something.

Given the long and lat for multi country competitions is often meaningless (or on null island) this can dramatically distort the statistic. Ideally all multi-location competitions would be excluded from the calculation, but it is hard to identify multi-location competitions which occur within one country within the Competitions table (unless I'm missing something). 