### PR TITLE
Fix longest standing records in case of ties

### DIFF
--- a/statistics/longest_standing_records.rb
+++ b/statistics/longest_standing_records.rb
@@ -50,10 +50,14 @@ class LongestStandingRecords < GroupedStatistic
           end
           .group_by { |result| result["event_id"] }
           .flat_map do |event_id, results|
-            results.each_cons(2) do |previous_record, new_record|
-              previous_record["days"] = new_record["competition_date"] - previous_record["competition_date"]
-            end
-            results.last["days"] = Date.today - results.last["competition_date"]
+	    results.each do |result_1|
+	      result_1["days"] = Date.today - result_1["competition_date"]
+	      results.each do |result_2|
+		if result_2[type] < result_1[type]
+		  result_1["days"] = [result_1["days"], result_2["competition_date"] - result_1["competition_date"]].min
+		end
+	      end
+	    end
             results
           end
           .map! do |result|

--- a/statistics/longest_standing_records.rb
+++ b/statistics/longest_standing_records.rb
@@ -50,14 +50,11 @@ class LongestStandingRecords < GroupedStatistic
           end
           .group_by { |result| result["event_id"] }
           .flat_map do |event_id, results|
-	    results.each do |result_1|
-	      result_1["days"] = Date.today - result_1["competition_date"]
-	      results.each do |result_2|
-		if result_2[type] < result_1[type]
-		  result_1["days"] = [result_1["days"], result_2["competition_date"] - result_1["competition_date"]].min
-		end
-	      end
-	    end
+            results.each do |result_1|
+              better_result = results.find { |result_2| result_2[type] < result_1[type] }
+              better_date = better_result ? better_result["competition_date"] : Date.today
+              result_1["days"] = better_date - result_1["competition_date"]
+            end
             results
           end
           .map! do |result|


### PR DESCRIPTION
When records are tied, they are counted as broken by the longest standing record statistic. This PR change this behavior, considering records broken only when the new record is strictly lower than the previous one.

Records affected:

* Sebastiano Tronto FMC single WR (hey that's me, what a coincidence!)
* Conor Cronin 3BLD average AfR
* Possibly more, I did not do an extensive check

P.S.: I am complete noob with Ruby and SQL, feel free to change the code if you don't like it!