### PR TITLE
Fix statistics broken after WCA database dump update

### DIFF
--- a/core/database.rb
+++ b/core/database.rb
@@ -16,8 +16,6 @@ module Database
     formats
     persons
     preferred_formats
-    ranks_single
-    ranks_average
     results
     result_attempts
     round_types

--- a/statistics/abstract/average_of_x.rb
+++ b/statistics/abstract/average_of_x.rb
@@ -7,7 +7,8 @@ class AverageOfX < GroupedStatistic
     @solve_count = solve_count
 
     @title = "Average of #{@solve_count}"
-    @note = "#{@solve_count} consecutive official attempts are considered. Only people from top 200 single are taken into account."
+    -- Take people from top 200 single for optimization reasons.
+    @note = "#{@solve_count} consecutive official attempts are considered. Only people from top 500 single are taken into account."
     @table_header = { "Ao#{@solve_count}" => :right, "Person" => :left, "Times" => :left }
   end
 
@@ -39,14 +40,13 @@ class AverageOfX < GroupedStatistic
             person_best.event_id,
             person_best.person_id,
             RANK() OVER (
-              PARTITION BY person_best.event_id, person_best.country_id
+              PARTITION BY person_best.event_id
               ORDER BY person_best.best
-            ) AS country_rank
+            ) AS world_rank
           FROM (
             SELECT
               r.event_id,
               r.person_id,
-              p.country_id,
               MIN(r.best) AS best
             FROM results r
             JOIN persons p
@@ -54,10 +54,11 @@ class AverageOfX < GroupedStatistic
              AND p.sub_id = 1
             WHERE r.best > 0
               AND r.event_id NOT IN ('333mbf', '333mbo')
-            GROUP BY r.event_id, r.person_id, p.country_id
+            GROUP BY r.event_id, r.person_id
           ) AS person_best
         ) ranked_people
-        WHERE country_rank <= 200
+        -- Take people from top 500 single for optimization reasons.
+        WHERE world_rank <= 500
       ) top_people
         ON top_people.event_id = result.event_id
        AND top_people.person_id = result.person_id

--- a/statistics/abstract/average_of_x.rb
+++ b/statistics/abstract/average_of_x.rb
@@ -23,13 +23,45 @@ class AverageOfX < GroupedStatistic
         result.event_id,
         ra.value
       FROM results result
-      JOIN persons person ON person.wca_id = person_id AND person.sub_id = 1
-      JOIN competitions competition ON competition.id = competition_id
-      JOIN round_types round_type ON round_type.id = round_type_id
-      JOIN ranks_single ON ranks_single.event_id = result.event_id AND ranks_single.person_id = result.person_id
-      JOIN result_attempts ra ON ra.result_id = result.id
-      -- Take people from top 200 single for optimization reasons.
-      WHERE ranks_single.country_rank <= 200 AND result.event_id NOT IN ('333mbf', '333mbo')
+      JOIN persons person
+        ON person.wca_id = result.person_id
+       AND person.sub_id = 1
+      JOIN competitions competition
+        ON competition.id = result.competition_id
+      JOIN round_types round_type
+        ON round_type.id = result.round_type_id
+      JOIN result_attempts ra
+        ON ra.result_id = result.id
+      JOIN (
+        SELECT event_id, person_id
+        FROM (
+          SELECT
+            person_best.event_id,
+            person_best.person_id,
+            RANK() OVER (
+              PARTITION BY person_best.event_id, person_best.country_id
+              ORDER BY person_best.best
+            ) AS country_rank
+          FROM (
+            SELECT
+              r.event_id,
+              r.person_id,
+              p.country_id,
+              MIN(r.best) AS best
+            FROM results r
+            JOIN persons p
+              ON p.wca_id = r.person_id
+             AND p.sub_id = 1
+            WHERE r.best > 0
+              AND r.event_id NOT IN ('333mbf', '333mbo')
+            GROUP BY r.event_id, r.person_id, p.country_id
+          ) AS person_best
+        ) ranked_people
+        WHERE country_rank <= 200
+      ) top_people
+        ON top_people.event_id = result.event_id
+       AND top_people.person_id = result.person_id
+      WHERE result.event_id NOT IN ('333mbf', '333mbo')
       ORDER BY competition.start_date, round_type.rank, ra.attempt_number
     SQL
   end

--- a/statistics/current_world_records_by_country.rb
+++ b/statistics/current_world_records_by_country.rb
@@ -14,20 +14,40 @@ class CurrentWorldRecordsByCountry < Statistic
         people
       FROM (
         SELECT
-          country_id,
-          COUNT(*) wrs_count,
+          person.country_id,
+          COUNT(*) AS wrs_count,
           GROUP_CONCAT(
             DISTINCT CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')')
             ORDER BY person.name
             SEPARATOR ', '
-          ) people
+          ) AS people
         FROM (
-          SELECT person_id FROM ranks_single WHERE world_rank = 1
+          SELECT r.person_id
+          FROM results r
+          JOIN (
+            SELECT event_id, MIN(best) AS wr_best
+            FROM results
+            WHERE best > 0
+            GROUP BY event_id
+          ) wr_single
+            ON wr_single.event_id = r.event_id
+           AND wr_single.wr_best = r.best
           UNION ALL
-          SELECT person_id FROM ranks_average WHERE world_rank = 1
+          SELECT r.person_id
+          FROM results r
+          JOIN (
+            SELECT event_id, MIN(average) AS wr_average
+            FROM results
+            WHERE average > 0
+            GROUP BY event_id
+          ) wr_average
+            ON wr_average.event_id = r.event_id
+           AND wr_average.wr_average = r.average
         ) AS ranks
-        JOIN persons person ON person.wca_id = person_id AND person.sub_id = 1
-        GROUP BY country_id
+        JOIN persons person
+          ON person.wca_id = ranks.person_id
+         AND person.sub_id = 1
+        GROUP BY person.country_id
       ) AS wrs_count_by_country
       JOIN countries country ON country.id = country_id
       ORDER BY wrs_count DESC, country.name

--- a/statistics/longest_time_to_sub_10.rb
+++ b/statistics/longest_time_to_sub_10.rb
@@ -10,26 +10,23 @@ class LongestTimeToSub10 < Statistic
     <<-SQL
       SELECT
         CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') person_link,
-        (DATEDIFF(first_sub_10_competition.start_date, first_competition.start_date) / 365.25) years
+        DATEDIFF(t.first_sub_10_date, t.first_comp_date) / 365.25 AS years
       FROM (
-        SELECT person_id
-        FROM ranks_average
-        WHERE event_id = '333' AND best < 1000
-      ) AS sub_10_person
-      JOIN (
-        SELECT person_id, MIN(start_date) start_date
-        FROM results
-        JOIN competitions competition ON competition.id = competition_id
-        GROUP BY person_id
-      ) AS first_competition ON first_competition.person_id = sub_10_person.person_id
-      JOIN (
-        SELECT person_id, MIN(start_date) start_date
-        FROM results
-        JOIN competitions competition ON competition.id = competition_id
-        WHERE event_id = '333' AND average > 0 AND average < 1000
-        GROUP BY person_id
-      ) AS first_sub_10_competition ON first_sub_10_competition.person_id = sub_10_person.person_id
-      JOIN persons person ON person.wca_id = sub_10_person.person_id AND sub_id = 1
+        SELECT
+          r.person_id,
+          MIN(c.start_date) AS first_comp_date,
+          MIN(CASE
+                WHEN r.event_id = '333' AND r.average > 0 AND r.average < 1000
+                THEN c.start_date
+              END) AS first_sub_10_date
+        FROM results r
+        JOIN competitions c ON c.id = r.competition_id
+        GROUP BY r.person_id
+      ) t
+      JOIN persons person
+        ON person.wca_id = t.person_id
+       AND person.sub_id = 1
+      WHERE t.first_sub_10_date IS NOT NULL
       ORDER BY years DESC
       LIMIT 100
     SQL

--- a/statistics/shortest_time_to_get_all_singles.rb
+++ b/statistics/shortest_time_to_get_all_singles.rb
@@ -11,37 +11,46 @@ class ShortestTimeToGetAllSingles < Statistic
   def query
     <<-SQL
       SELECT
-        event_id,
-        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') person_link,
-        start_date,
-        best
+        DATEDIFF(completion.last_first_success_date, first_comp.first_competition_date) AS days,
+        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') AS person_link
       FROM (
-        -- People who have single for every official event.
-        SELECT person_id
-        FROM ranks_single
-        JOIN events event ON event.id = event_id
-        WHERE event.rank < 900
-        GROUP BY person_id
-        HAVING COUNT(event_id) = #{Events::OFFICIAL.length}
-      ) AS all_events_people
-      JOIN results result ON result.person_id = all_events_people.person_id
-      JOIN persons person ON person.wca_id = result.person_id and person.sub_id = 1
-      JOIN competitions competition ON competition.id = competition_id
-      ORDER BY start_date
+        SELECT
+          s.person_id,
+          MAX(s.first_success_date) AS last_first_success_date
+        FROM (
+          SELECT
+            r.person_id,
+            r.event_id,
+            MIN(c.start_date) AS first_success_date
+          FROM results r
+          JOIN competitions c ON c.id = r.competition_id
+          JOIN events e ON e.id = r.event_id
+          WHERE e.rank < 900
+            AND r.best > 0
+          GROUP BY r.person_id, r.event_id
+        ) s
+        GROUP BY s.person_id
+        HAVING COUNT(*) = #{Events::OFFICIAL.length}
+      ) completion
+      JOIN (
+        SELECT
+          r.person_id,
+          MIN(c.start_date) AS first_competition_date
+        FROM results r
+        JOIN competitions c ON c.id = r.competition_id
+        GROUP BY r.person_id
+      ) first_comp
+        ON first_comp.person_id = completion.person_id
+      JOIN persons person
+        ON person.wca_id = completion.person_id
+       AND person.sub_id = 1
+      ORDER BY days ASC
     SQL
   end
 
   def transform(query_results)
-    query_results
-      .group_by { |result| result["person_link"] }
-      .map do |person_link, results|
-        first_competition_date = results[0]["start_date"]
-        first_successes = results
-          .select { |result| result["best"] > 0 }
-          .group_by { |result| result["event_id"] }
-          .map { |event_id, results| results.map { |result| result["start_date"] }.min }
-        [(first_successes.max - first_competition_date).to_i, person_link]
-      end
-      .sort_by! { |days, person_link| days }
+    query_results.map do |result|
+      [result["days"].to_i, result["person_link"]]
+    end
   end
 end

--- a/statistics/shortest_time_to_get_all_singles_and_averages.rb
+++ b/statistics/shortest_time_to_get_all_singles_and_averages.rb
@@ -14,49 +14,69 @@ class ShortestTimeToGetAllSinglesAndAverages < Statistic
   def query
     <<-SQL
       SELECT
-        event_id,
-        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') person_link,
-        start_date,
-        best,
-        average
+        DATEDIFF(
+          GREATEST(single_completion.last_single_date, average_completion.last_average_date),
+          first_comp.first_competition_date
+        ) AS days,
+        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') AS person_link
       FROM (
-        -- People who have single for every official event.
-        SELECT person_id
-        FROM ranks_single
-        JOIN events event ON event.id = event_id
-        WHERE event.rank < 900
-        GROUP BY person_id
-        HAVING COUNT(event_id) = #{Events::OFFICIAL.length}
-      ) AS all_events_people
+        SELECT
+          s.person_id,
+          MAX(s.first_single_date) AS last_single_date
+        FROM (
+          SELECT
+            r.person_id,
+            r.event_id,
+            MIN(c.start_date) AS first_single_date
+          FROM results r
+          JOIN competitions c ON c.id = r.competition_id
+          JOIN events e ON e.id = r.event_id
+          WHERE e.rank < 900
+            AND r.best > 0
+          GROUP BY r.person_id, r.event_id
+        ) s
+        GROUP BY s.person_id
+        HAVING COUNT(*) = #{Events::OFFICIAL.length}
+      ) single_completion
       JOIN (
-        -- People who have average for every official event.
-        SELECT person_id
-        FROM ranks_average
-        JOIN events event ON event.id = event_id
-        WHERE event.rank < 900
-        GROUP BY person_id
-        HAVING COUNT(event_id) = #{NUM_EVENTS_WITH_AVERAGES}
-      ) AS all_average_people ON all_average_people.person_id = all_events_people.person_id
-      JOIN results result ON result.person_id = all_events_people.person_id
-      JOIN persons person ON person.wca_id = result.person_id and person.sub_id = 1
-      JOIN competitions competition ON competition.id = competition_id
-      ORDER BY start_date
+        SELECT
+          a.person_id,
+          MAX(a.first_average_date) AS last_average_date
+        FROM (
+          SELECT
+            r.person_id,
+            r.event_id,
+            MIN(c.start_date) AS first_average_date
+          FROM results r
+          JOIN competitions c ON c.id = r.competition_id
+          JOIN events e ON e.id = r.event_id
+          WHERE e.rank < 900
+            AND r.average > 0
+          GROUP BY r.person_id, r.event_id
+        ) a
+        GROUP BY a.person_id
+        HAVING COUNT(*) = #{NUM_EVENTS_WITH_AVERAGES}
+      ) average_completion
+        ON average_completion.person_id = single_completion.person_id
+      JOIN (
+        SELECT
+          r.person_id,
+          MIN(c.start_date) AS first_competition_date
+        FROM results r
+        JOIN competitions c ON c.id = r.competition_id
+        GROUP BY r.person_id
+      ) first_comp
+        ON first_comp.person_id = single_completion.person_id
+      JOIN persons person
+        ON person.wca_id = single_completion.person_id
+       AND person.sub_id = 1
+      ORDER BY days ASC
     SQL
   end
 
   def transform(query_results)
-    query_results
-      .group_by { |result| result["person_link"] }
-      .map do |person_link, results|
-        first_competition_date = results[0]["start_date"]
-        first_successes = %w(best average).flat_map do |type|
-          results
-            .select { |result| result[type] > 0 }
-            .group_by { |result| result["event_id"] }
-            .map { |event_id, results| results.map { |result| result["start_date"] }.min }
-        end
-        [(first_successes.max - first_competition_date).to_i, person_link]
-      end
-      .sort_by! { |days, person_link| days }
+    query_results.map do |result|
+      [result["days"].to_i, result["person_link"]]
+    end
   end
 end


### PR DESCRIPTION
### Updated statistics

- Longest time to achieve sub 10 3x3x3 average
- Shortest time to get all singles
- Shortest time to get all singles and averages
- Current world records count by country
- Average of X (abstract)

The queries may not be fully optimized and could contain some mistakes, so a careful review would be appreciated.