### PR TITLE
Add sequential numbering to statistics tables

### DIFF
--- a/core/statistic.rb
+++ b/core/statistic.rb
@@ -33,11 +33,12 @@ class Statistic
   end
 
   def markdown_table(header, data)
-    table = "| #{header.keys.join(' | ')} |\n"
+    numbered_header = { "#" => :right }.merge(header)
+    table = "| #{numbered_header.keys.join(' | ')} |\n"
     alignments = { left: ":---", center: ":--:", right: "---:" }
-    table += "| #{header.values.map { |alignment| alignments[alignment] }.join(' | ')} |\n"
-    data.each do |row|
-      table += "| #{row.join(' | ')} |\n"
+    table += "| #{numbered_header.values.map { |alignment| alignments[alignment] }.join(' | ')} |\n"
+    data.each_with_index do |row, index|
+      table += "| #{([index + 1] + row).join(' | ')} |\n"
     end
     table
   end


### PR DESCRIPTION
This change adds a numbered first column to every generated statistics table.

- The new column is rendered as #
- Rows are numbered sequentially starting from 1
- Tie handling is not included in this change; rows are numbered strictly by their existing output order
- The change is applied in the shared table formatter, so both single-table and grouped-table outputs are covered

If you think this change is unnecessary, feel free to reject it.