### PR TITLE
Add most records delegated

### DIFF
--- a/statistics/most_records_delegated.rb
+++ b/statistics/most_records_delegated.rb
@@ -1,0 +1,84 @@
+require_relative "../core/statistic"
+
+class MostRecordsDelegated < Statistic
+  def initialize
+    @title = "Most Records at Delegated Competitions"
+    @note = "Counts World Records (WR), Continental Records (CR), and National Records (NR) achieved in competitions where the person was the official delegate. CR includes ER, AfR, AsR, OcR, NAR, and SAR."
+    @table_header = {
+      "Records" => :right,
+      "WR / CR / NR breakdown" => :left,
+      "Delegate" => :left
+    }
+  end
+
+  def query
+    <<-SQL
+      SELECT
+        total_records,
+        breakdown,
+        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') AS delegate
+      FROM (
+        SELECT
+          delegate_id,
+          SUM(cnt) AS total_records,
+          GROUP_CONCAT(
+            CONCAT(cnt, 'x', record_class)
+            ORDER BY
+              CASE record_class
+                WHEN 'WR' THEN 1
+                WHEN 'CR' THEN 2
+                WHEN 'NR' THEN 3
+              END
+            SEPARATOR ', '
+          ) AS breakdown
+        FROM (
+          SELECT
+            delegate_id,
+            record_class,
+            SUM(cnt) AS cnt
+          FROM (
+            -- SINGLE RECORDS
+            SELECT
+              cd.delegate_id,
+              CASE
+                WHEN r.regional_single_record = 'WR' THEN 'WR'
+                WHEN r.regional_single_record IN ('ER','AfR','AsR','OcR','NAR','SAR') THEN 'CR'
+                WHEN r.regional_single_record = 'NR' THEN 'NR'
+                ELSE NULL
+              END AS record_class,
+              COUNT(*) AS cnt
+            FROM competition_delegates cd
+            JOIN results r
+              ON r.competition_id = cd.competition_id
+            WHERE r.regional_single_record IS NOT NULL
+            GROUP BY cd.delegate_id, record_class
+
+            UNION ALL
+
+            -- AVERAGE RECORDS
+            SELECT
+              cd.delegate_id,
+              CASE
+                WHEN r.regional_average_record = 'WR' THEN 'WR'
+                WHEN r.regional_average_record IN ('ER','AfR','AsR','OcR','NAR','SAR') THEN 'CR'
+                WHEN r.regional_average_record = 'NR' THEN 'NR'
+                ELSE NULL
+              END AS record_class,
+              COUNT(*) AS cnt
+            FROM competition_delegates cd
+            JOIN results r
+              ON r.competition_id = cd.competition_id
+            WHERE r.regional_average_record IS NOT NULL
+            GROUP BY cd.delegate_id, record_class
+          ) raw
+          GROUP BY delegate_id, record_class
+        ) classified
+        GROUP BY delegate_id
+      ) stats
+      JOIN users u ON u.id = stats.delegate_id
+      JOIN persons person ON person.wca_id = u.wca_id AND person.sub_id = 1
+      ORDER BY total_records DESC
+      LIMIT 100
+    SQL
+  end
+end

--- a/statistics/most_records_delegated.rb
+++ b/statistics/most_records_delegated.rb
@@ -5,80 +5,77 @@ class MostRecordsDelegated < Statistic
     @title = "Most records delegated"
     @note = "Counts World Records (WR), Continental Records (CR), and National Records (NR) achieved in competitions where the person was the official delegate."
     @table_header = {
-      "Records" => :right,
-      "WR / CR / NR breakdown" => :left,
-      "Delegate" => :left
-    }
+     "Records" => :right,
+     "WR" => :right,
+     "CR" => :right,
+     "NR" => :right,
+     "Delegate" => :left
+}
   end
 
   def query
     <<-SQL
       SELECT
-        total_records,
-        breakdown,
-        CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') AS delegate
-      FROM (
-        SELECT
-          delegate_id,
-          SUM(cnt) AS total_records,
-          GROUP_CONCAT(
-            CONCAT(cnt, 'x', record_class)
-            ORDER BY
-              CASE record_class
-                WHEN 'WR' THEN 1
-                WHEN 'CR' THEN 2
-                WHEN 'NR' THEN 3
-              END
-            SEPARATOR ', '
-          ) AS breakdown
-        FROM (
-          SELECT
-            delegate_id,
-            record_class,
-            SUM(cnt) AS cnt
-          FROM (
-            -- SINGLE RECORDS
-            SELECT
-              cd.delegate_id,
-              CASE
-                WHEN r.regional_single_record = 'WR' THEN 'WR'
-                WHEN r.regional_single_record IN ('ER','AfR','AsR','OcR','NAR','SAR') THEN 'CR'
-                WHEN r.regional_single_record = 'NR' THEN 'NR'
-                ELSE NULL
-              END AS record_class,
-              COUNT(*) AS cnt
-            FROM competition_delegates cd
-            JOIN results r
-              ON r.competition_id = cd.competition_id
-            WHERE r.regional_single_record IS NOT NULL
-            GROUP BY cd.delegate_id, record_class
+  total_records,
+  wr_records,
+  cr_records,
+  nr_records,
+  CONCAT('[', person.name, '](https://www.worldcubeassociation.org/persons/', person.wca_id, ')') AS delegate
+FROM (
+  SELECT
+    delegate_id,
+    SUM(cnt) AS total_records,
+    SUM(CASE WHEN record_class = 'WR' THEN cnt ELSE 0 END) AS wr_records,
+    SUM(CASE WHEN record_class = 'CR' THEN cnt ELSE 0 END) AS cr_records,
+    SUM(CASE WHEN record_class = 'NR' THEN cnt ELSE 0 END) AS nr_records
+  FROM (
+    SELECT
+      delegate_id,
+      record_class,
+      SUM(cnt) AS cnt
+    FROM (
+      -- SINGLE RECORDS
+      SELECT
+        cd.delegate_id,
+        CASE
+          WHEN r.regional_single_record = 'WR' THEN 'WR'
+          WHEN r.regional_single_record IN ('ER','AfR','AsR','OcR','NAR','SAR') THEN 'CR'
+          WHEN r.regional_single_record = 'NR' THEN 'NR'
+          ELSE NULL
+        END AS record_class,
+        COUNT(*) AS cnt
+      FROM competition_delegates cd
+      JOIN results r
+        ON r.competition_id = cd.competition_id
+      WHERE r.regional_single_record IS NOT NULL
+      GROUP BY cd.delegate_id, record_class
 
-            UNION ALL
+      UNION ALL
 
-            -- AVERAGE RECORDS
-            SELECT
-              cd.delegate_id,
-              CASE
-                WHEN r.regional_average_record = 'WR' THEN 'WR'
-                WHEN r.regional_average_record IN ('ER','AfR','AsR','OcR','NAR','SAR') THEN 'CR'
-                WHEN r.regional_average_record = 'NR' THEN 'NR'
-                ELSE NULL
-              END AS record_class,
-              COUNT(*) AS cnt
-            FROM competition_delegates cd
-            JOIN results r
-              ON r.competition_id = cd.competition_id
-            WHERE r.regional_average_record IS NOT NULL
-            GROUP BY cd.delegate_id, record_class
-          ) raw
-          GROUP BY delegate_id, record_class
-        ) classified
-        GROUP BY delegate_id
-      ) stats
-      JOIN users u ON u.id = stats.delegate_id
-      JOIN persons person ON person.wca_id = u.wca_id AND person.sub_id = 1
-      ORDER BY total_records DESC
-      LIMIT 100
+      -- AVERAGE RECORDS
+      SELECT
+        cd.delegate_id,
+        CASE
+          WHEN r.regional_average_record = 'WR' THEN 'WR'
+          WHEN r.regional_average_record IN ('ER','AfR','AsR','OcR','NAR','SAR') THEN 'CR'
+          WHEN r.regional_average_record = 'NR' THEN 'NR'
+          ELSE NULL
+        END AS record_class,
+        COUNT(*) AS cnt
+      FROM competition_delegates cd
+      JOIN results r
+        ON r.competition_id = cd.competition_id
+      WHERE r.regional_average_record IS NOT NULL
+      GROUP BY cd.delegate_id, record_class
+    ) raw
+    GROUP BY delegate_id, record_class
+  ) classified
+  GROUP BY delegate_id
+) stats
+JOIN users u ON u.id = stats.delegate_id
+JOIN persons person ON person.wca_id = u.wca_id AND person.sub_id = 1
+ORDER BY total_records DESC
+LIMIT 100
     SQL
   end
 end

--- a/statistics/most_records_delegated.rb
+++ b/statistics/most_records_delegated.rb
@@ -2,7 +2,7 @@ require_relative "../core/statistic"
 
 class MostRecordsDelegated < Statistic
   def initialize
-    @title = "Most Records Delegated"
+    @title = "Most records delegated"
     @note = "Counts World Records (WR), Continental Records (CR), and National Records (NR) achieved in competitions where the person was the official delegate."
     @table_header = {
       "Records" => :right,

--- a/statistics/most_records_delegated.rb
+++ b/statistics/most_records_delegated.rb
@@ -2,7 +2,7 @@ require_relative "../core/statistic"
 
 class MostRecordsDelegated < Statistic
   def initialize
-    @title = "Most Records at Delegated Competitions"
+    @title = "Most Records Delegated"
     @note = "Counts World Records (WR), Continental Records (CR), and National Records (NR) achieved in competitions where the person was the official delegate. CR includes ER, AfR, AsR, OcR, NAR, and SAR."
     @table_header = {
       "Records" => :right,

--- a/statistics/most_records_delegated.rb
+++ b/statistics/most_records_delegated.rb
@@ -3,7 +3,7 @@ require_relative "../core/statistic"
 class MostRecordsDelegated < Statistic
   def initialize
     @title = "Most Records Delegated"
-    @note = "Counts World Records (WR), Continental Records (CR), and National Records (NR) achieved in competitions where the person was the official delegate. CR includes ER, AfR, AsR, OcR, NAR, and SAR."
+    @note = "Counts World Records (WR), Continental Records (CR), and National Records (NR) achieved in competitions where the person was the official delegate."
     @table_header = {
       "Records" => :right,
       "WR / CR / NR breakdown" => :left,


### PR DESCRIPTION
Hi Jonatan,

This pull request adds a new statistic ranking delegates by the number of records achieved at competitions they delegated.

The statistic counts:

* WR (World Records)
* CR (Continental Records), combining ER, AfR, AsR, OcR, NAR and SAR
* NR (National Records)

Both single and average records are included.

The output includes a total record count together with a WR / CR / NR breakdown for each delegate.

I think I've done all of this correctly, but it's my first ever GitHub Pull Request.

Kind regards,

AJ