### PR TITLE
Add most N/N multi-blind successes statistic

### DIFF
--- a/statistics/most_nxn_multi_blind_successes.rb
+++ b/statistics/most_nxn_multi_blind_successes.rb
@@ -1,0 +1,72 @@
+require_relative "../core/statistic"
+
+class MostNxnMultiBlindSuccesses < Statistic
+  def initialize
+    @title = "Most N/N 3x3 Multi-Blind Successes"
+    @note = "Count of all 3x3 Multi-Blind Successes where all cubes were solved."
+    @table_header = {
+      "Name" => :left,
+      "N/N Successes" => :right,
+      "Breakdown" => :left
+    }
+  end
+
+  def query
+    <<-SQL
+      WITH nn_multis AS (
+        SELECT
+          p.wca_id,
+          p.name,
+          (
+            (99 - FLOOR(ra.value / 10000000))
+            + MOD(ra.value, 100)
+          ) AS nn_level
+        FROM results r
+        JOIN result_attempts ra
+          ON ra.result_id = r.id
+        JOIN persons p
+          ON p.wca_id = r.person_id
+         AND p.sub_id = 1
+        WHERE r.event_id = '333mbf'
+          AND ra.value > 0
+          AND MOD(ra.value, 100) = 0
+      ),
+
+      nn_counts AS (
+        SELECT
+          wca_id,
+          name,
+          nn_level,
+          COUNT(*) AS occurrences
+        FROM nn_multis
+        GROUP BY
+          wca_id,
+          name,
+          nn_level
+      )
+
+      SELECT
+        CONCAT('[', name, '](https://www.worldcubeassociation.org/persons/', wca_id, ')') AS name,
+        SUM(occurrences) AS nn_successes,
+        GROUP_CONCAT(
+          CASE
+            WHEN occurrences = 1
+              THEN CONCAT(nn_level, '/', nn_level)
+            ELSE
+              CONCAT(nn_level, '/', nn_level, ' (', occurrences, ')')
+          END
+          ORDER BY nn_level
+          SEPARATOR ', '
+        ) AS breakdown
+      FROM nn_counts
+      GROUP BY
+        wca_id,
+        name
+      HAVING SUM(occurrences) >= 6
+      ORDER BY
+        nn_successes DESC,
+        MAX(nn_level) DESC,
+        name
+    SQL
+  end
+end


### PR DESCRIPTION
Adds a statistic ranking competitors by the number of successful N/N 3x3 Multi-Blind attempts.

An attempt is counted when all attempted cubes were solved, for example 5/5, 10/10 or 20/20.

The table displays:

- Total N/N successes
- A breakdown of the successful cube counts achieved by each competitor

To keep the table relatively concise, only competitors with at least 6 N/N successes are included.